### PR TITLE
Fix wrong parent type for Open with dialog

### DIFF
--- a/hyperplane/items_page.py
+++ b/hyperplane/items_page.py
@@ -391,7 +391,7 @@ class HypItemsPage(Adw.NavigationPage):
         win = self.get_root()
 
         portal = Xdp.Portal()
-        parent = XdpGtk4.parent_new_gtk(self)
+        parent = XdpGtk4.parent_new_gtk(win)
         gfiles = win.get_gfiles_from_positions(win.get_selected_items())
         if not gfiles:
             return


### PR DESCRIPTION
This fixes an issue where the "Open with" dialog was not opening because of wrong parent type passed.

```yaml
Traceback (most recent call last):
  File "/app/lib/python3.11/site-packages/hyperplane/items_page.py", line 394, in __open_with
    parent = XdpGtk4.parent_new_gtk(self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument window: Expected Gtk.Window, but got hyperplane.items_page.HypItemsPage
```