### PR TITLE
Fix inconsistent grid item colors

### DIFF
--- a/hyperplane/item.py
+++ b/hyperplane/item.py
@@ -120,14 +120,17 @@ class HypItem(Adw.Bin):
         self.icon.set_visible(failed)
         self.picture.set_visible(not failed)
 
+        self.icon.set_css_classes(["large-icons"])
+        self.thumbnail.set_css_classes(["item-thumbnail"])
+        self.extension_label.set_css_classes(["file-extension"])
+
         if failed:
             self.icon.add_css_class(self.color + "-icon")
             self.thumbnail.add_css_class(self.color + "-background")
             self.extension_label.add_css_class(self.color + "-extension")
-            return
-
-        self.thumbnail.add_css_class("gray-background")
-        self.extension_label.add_css_class(self.color + "-extension-thumb")
+        else:
+            self.thumbnail.add_css_class("gray-background")
+            self.extension_label.add_css_class(self.color + "-extension-thumb")
 
     def __build_file_thumbnail(self) -> None:
         if self.extension:

--- a/hyperplane/item.py
+++ b/hyperplane/item.py
@@ -126,9 +126,10 @@ class HypItem(Adw.Bin):
             self.icon.add_css_class(self.color + "-icon")
             self.thumbnail.add_css_class(self.color + "-background")
             self.extension_label.add_css_class(self.color + "-extension")
-        else:
-            self.thumbnail.add_css_class("gray-background")
-            self.extension_label.add_css_class(self.color + "-extension-thumb")
+            return
+    
+        self.thumbnail.add_css_class("gray-background")
+        self.extension_label.add_css_class(self.color + "-extension-thumb")
 
     def __build_file_thumbnail(self) -> None:
         if self.extension:

--- a/hyperplane/item.py
+++ b/hyperplane/item.py
@@ -127,7 +127,7 @@ class HypItem(Adw.Bin):
             self.thumbnail.add_css_class(self.color + "-background")
             self.extension_label.add_css_class(self.color + "-extension")
             return
-    
+
         self.thumbnail.add_css_class("gray-background")
         self.extension_label.add_css_class(self.color + "-extension-thumb")
 

--- a/hyperplane/item.py
+++ b/hyperplane/item.py
@@ -104,7 +104,9 @@ class HypItem(Adw.Bin):
 
     def unbind(self) -> None:
         """Cleanup after the object has been unbound from its item."""
-        return  # TODO: Clean up
+        self.icon.set_css_classes(["large-icons"])
+        self.thumbnail.set_css_classes(["item-thumbnail"])
+        self.extension_label.set_css_classes(["file-extension"])
 
     def __build(self) -> None:
         self.play_button.set_visible(False)
@@ -119,10 +121,6 @@ class HypItem(Adw.Bin):
     def __file_thumb_done(self, failed: bool) -> None:
         self.icon.set_visible(failed)
         self.picture.set_visible(not failed)
-
-        self.icon.set_css_classes(["large-icons"])
-        self.thumbnail.set_css_classes(["item-thumbnail"])
-        self.extension_label.set_css_classes(["file-extension"])
 
         if failed:
             self.icon.add_css_class(self.color + "-icon")


### PR DESCRIPTION
The CSS classes need to be reset before adding new ones, otherwise the item's colors will be quite random.