### PR TITLE
Add option to activate items with a single click

### DIFF
--- a/data/hu.kramo.Hyperplane.gschema.xml.in
+++ b/data/hu.kramo.Hyperplane.gschema.xml.in
@@ -16,6 +16,9 @@
 		<key name="hidden-locations" type="as">
 			<default>[]</default>
 		</key>
+		<key name="single-click-open" type="b">
+			<default>false</default>
+		</key>
 	</schema>
 
 	<schema id="@APP_ID@.State" path="@PREFIX@/State/">

--- a/hyperplane/gtk/preferences.blp
+++ b/hyperplane/gtk/preferences.blp
@@ -10,6 +10,10 @@ template $HypPreferencesWindow : Adw.PreferencesWindow {
       Adw.SwitchRow folders_switch_row {
         title: _("Sort Folders Before Files");
       }
+
+      Adw.SwitchRow single_click_open_switch_row {
+        title: _("Activate Items With a Single Click");
+      }
     }
   }
 }

--- a/hyperplane/items_page.py
+++ b/hyperplane/items_page.py
@@ -192,6 +192,20 @@ class HypItemsPage(Adw.NavigationPage):
         self.scroll.connect("scroll", self.__scroll)
         self.scrolled_window.add_controller(self.scroll)
 
+        shared.schema.bind(
+            "single-click-open",
+            self.grid_view,
+            "single-click-activate",
+            Gio.SettingsBindFlags.DEFAULT,
+        )
+
+        shared.schema.bind(
+            "single-click-open",
+            self.column_view,
+            "single-click-activate",
+            Gio.SettingsBindFlags.DEFAULT,
+        )
+
     def reload(self) -> None:
         """Refresh the view."""
         if isinstance(self.dir_list, Gtk.DirectoryList):

--- a/hyperplane/preferences.py
+++ b/hyperplane/preferences.py
@@ -30,6 +30,7 @@ class HypPreferencesWindow(Adw.PreferencesWindow):
     __gtype_name__ = "HypPreferencesWindow"
 
     folders_switch_row = Gtk.Template.Child()
+    single_click_open_switch_row = Gtk.Template.Child()
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
@@ -37,6 +38,13 @@ class HypPreferencesWindow(Adw.PreferencesWindow):
         shared.schema.bind(
             "folders-before-files",
             self.folders_switch_row,
+            "active",
+            Gio.SettingsBindFlags.DEFAULT,
+        )
+
+        shared.schema.bind(
+            "single-click-open",
+            self.single_click_open_switch_row,
             "active",
             Gio.SettingsBindFlags.DEFAULT,
         )


### PR DESCRIPTION
This is always the first thing I enable in Nautilus, but it's also much better for mobile. Should probably be the default on mobile (idk, how).

Unlike Nautilus, I used a switch here instead of the combo box, as having a combo with only to items doesn't really make sense, and it would also complicate the implementation significantly (sadly `Gio.Settings.bind_with_mapping` is not available to language bindings)