### PR TITLE
Fix formatting in `window.blp`

### DIFF
--- a/hyperplane/gtk/window.blp
+++ b/hyperplane/gtk/window.blp
@@ -197,12 +197,8 @@ template $HypWindow : Adw.ApplicationWindow {
                 ]
               }
             }
-          }
-
-          ;
-        }
-
-        ;
+          };
+        };
         content:
         Adw.ToolbarView toolbar_view {
 
@@ -303,9 +299,7 @@ template $HypWindow : Adw.ApplicationWindow {
         ;
       }
     }
-  }
-
-  ;
+  };
 
   styles [
     "view",


### PR DESCRIPTION
This PR fixes the separated semicolons in the `window.blp` file to the correct place.