### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/page.kramo.Hyperplane.metainfo.xml.in
+++ b/data/page.kramo.Hyperplane.metainfo.xml.in
@@ -13,9 +13,9 @@
 	<url type="contact">https://www.kramo.page/about/</url>
 	<url type="vcs-browser">https://github.com/kra-mo/hyperplane</url>
 	<!-- developer_name tag deprecated with Appstream 1.0 -->
-	<developer_name translatable="no">kramo</developer_name>
+	<developer_name translate="no">kramo</developer_name>
 	<developer id="page.kramo">
-		<name translatable="no">kramo</name>
+		<name translate="no">kramo</name>
 	</developer>
 	<launchable type="desktop-id">@APP_ID@.desktop</launchable>
 	<translation type="gettext">hyperplane</translation>
@@ -37,7 +37,7 @@
 	<content_rating type="oars-1.1" />
 	<releases>
 		<release version="0.5.1-beta" date="2024-03-25">
-			<description translatable="no">
+			<description translate="no">
 				<ul>
 					<li>Fixed drag and drop on the latest nightly runtime</li>
 					<li>The cursor now indicates that empty space in the path bar is clickable</li>
@@ -46,7 +46,7 @@
 			</description>
 		</release>
 		<release version="0.5.0-beta" date="2024-02-18">
-			<description translatable="no">
+			<description translate="no">
 				<ul>
 					<li>Improved thumbnailing inside Flatpak</li>
 					<li>Fixed drag and drop (again, hopefully finally)</li>
@@ -55,7 +55,7 @@
 			</description>
 		</release>
 		<release version="0.4.1-beta" date="2024-01-30">
-			<description translatable="no">
+			<description translate="no">
 				<ul>
 					<li>Changed the app ID</li>
 					<li>Fixed dragging and dropping to Firefox</li>
@@ -64,7 +64,7 @@
 			</description>
 		</release>
 		<release version="0.4.0-beta" date="2024-01-27">
-			<description translatable="no">
+			<description translate="no">
 				<ul>
 					<li>Added the ability to run executable files</li>
 					<li>Updated to new adaptive dialogs</li>
@@ -73,7 +73,7 @@
 			</description>
 		</release>
 		<release version="0.3.0-beta" date="2024-01-15">
-			<description translatable="no">
+			<description translate="no">
 				<ul>
 					<li>Improved dragging and dropping</li>
 					<li>Added banners to special locations</li>
@@ -82,7 +82,7 @@
 			</description>
 		</release>
 		<release version="0.2.0-beta" date="2024-01-10">
-			<description translatable="no">
+			<description translate="no">
 				<ul>
 					<li>The app now shows additional tags under tagged items</li>
 					<li>Small fixes</li>
@@ -90,7 +90,7 @@
 			</description>
 		</release>
 		<release version="0.1.0-beta" date="2024-01-02">
-		  <description translatable="no">
+		  <description translate="no">
 			<p>Initial beta release</p>
 		  </description>
 		</release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html